### PR TITLE
dApp: Fix networkId comparison

### DIFF
--- a/dapp/src/utils/network.ts
+++ b/dapp/src/utils/network.ts
@@ -10,7 +10,7 @@ export const SUPPORTED_NETWORKS = {
 export const SUPPORTED_NETWORKS_MAP = invert(SUPPORTED_NETWORKS)
 
 export const isMainNet = networkId =>
-  networkId === SUPPORTED_NETWORKS_MAP.MAINNET
+  String(networkId) === SUPPORTED_NETWORKS_MAP.MAINNET
 
 const getEtherScanBaseURL = networkId => {
   const network = SUPPORTED_NETWORKS[networkId]


### PR DESCRIPTION
This fixes the etherscan toast link for mainnet

the isMainNet comparison was always false as networkId is always a number and SUPPORTED_NETWORKS_MAP.MAINNET is a string